### PR TITLE
feat: add extensible sort/group att values

### DIFF
--- a/csl-next.rnc
+++ b/csl-next.rnc
@@ -56,6 +56,16 @@ render.fmt =
   attribute substitute {
     list { render.vars }
   }?
+
+## sort and group values; the included options here provide flexibility on how grouping
+## happens in different context.
+## TODO this in general needs more thought
+sort-group.vals =
+  "cs:author" | "cs:year" | "cs:author-year" | custom.att.val.pattern
+
+## Allows custom pseudo namespace-prefixed attribute values.
+custom.att.val.pattern =
+  (xsd:NMTOKEN - (xsd:NMTOKEN { pattern = "cs:.*" }))
 # Render List element
 render.list =
   element list {
@@ -63,11 +73,11 @@ render.list =
     
     ## REVIEW Will this work?
     ## if yes, could probably more flexibility
-    attribute sort { csl.token }?,
+    attribute sort { sort-group.vals }?,
     
     ## a list of variables (or templates?) to group by; a common value might be,
     ## for example, "author date.year"
-    attribute group-by { csl.token.list }?,
+    attribute group-by { sort-group.vals }?,
     
     ## we could do this with transforms, but don't need to
     ## and here we generalize this, so can work in different context

--- a/csl1-next.xsl
+++ b/csl1-next.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:cs="http://purl.org/net/xbiblio/csl"
+                xmlns="http://purl.org/net/xbiblio/csl/2"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="1.0">
+
+  <!-- converts CSL 1.0 to 1.1 -->
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:strip-space elements="*"/>
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- update version number -->
+  <xsl:template match="@version[.='1.0']">
+    <xsl:attribute name="version">2.0</xsl:attribute>
+  </xsl:template>
+
+  <!-- template to change the namespace -->
+  <xsl:template match="cs:*">
+    <xsl:element name="{local-name()}" namespace="http://purl.org/net/xbiblio/csl/2">
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- strip elements with these deprecated attribute values -->
+  <xsl:template match="//cs:link[@rel='independent-parent']"/>
+  <xsl:template match="//cs:link[@rel='template']"/>
+
+  <!-- convert stuff to generic list -->
+  <xsl:template match="//cs:group|//cs:layout|//cs:names">
+    <list>
+      <xsl:apply-templates select="*|@*"/>
+    </list>
+  </xsl:template>
+
+  <xsl:template match="//cs:text">
+    <reference>
+      <xsl:apply-templates select="*|@*"/>
+    </reference>
+  </xsl:template>
+
+  <xsl:template match="//cs:macro">
+    <template>
+      <xsl:apply-templates select="*|@*"/>
+    </template>
+  </xsl:template>
+
+
+</xsl:stylesheet>

--- a/examples/style.xml
+++ b/examples/style.xml
@@ -14,8 +14,8 @@
     <!-- configure sort/group in templates -->
     <if mode="narrative">
       <list delimiter=", "
-	          group-by="author"
-            sort="author">
+	          group-by="cs:author"
+            sort="cs:author">
 	      <reference template="apa-authors"/>
 	      <list prefix="(" suffix=")">
           <reference template="date-year"/>
@@ -25,7 +25,7 @@
     </if>
     <else>
       <!-- parenthetical author-date citation -->
-      <list group-by="author date.year"
+      <list group-by="cs:author-year"
             prefix="(" suffix=")"
             delimiter="; ">
         <reference template="author-paren" suffix=", "/>
@@ -35,8 +35,8 @@
     </else>
   </citation>
   <bibliography>
-    <list sort="author-year"
-          group-by="author-year">
+    <list sort="cs:author-year"
+          group-by="cs:author-year">
       <reference term="todo"/>
     </list>
   </bibliography>


### PR DESCRIPTION
Have a constrained list, with an obvious value like `cs:author-year`, but allow for extension.

This is a different strategy to sorting and grouping than CSL 1. Not sure it's a good idea or not.

And if in general it is a good idea, the details need more thought to ensure it's suitably flexible and clear.

But if could be a general approach to attribute values, so the pattern could work, for example, for variable names.

Close: #19.